### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ url
 plugins
 jenkins_home/plugins
 jenkins_home/war
-jenkins_home/credentials.xml
 jenkins_home/identity.key.enc
 jenkins_home/init.groovy.d
 jenkins_home/jobs


### PR DESCRIPTION
delete /credentials from ignore list, because slave nodes can't get credentials id without this directory
